### PR TITLE
Add testcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,26 +213,21 @@ Notice that `# Group B` moved with `"bravo"`, and the original grouping is lost 
 If you need to maintain specific groups of elements or a precise manual order within a list:
 
 1.  **Use `# tfsort:ignore`:** Add the `# tfsort:ignore` comment immediately after the opening bracket `[` to disable sorting for the entire list.
-2.  **Split the List:** Define multiple separate lists, potentially using local variables, and manage their contents independently. For example:
+2.  **Split the List:** Define multiple separate lists and concat them. For example:
 
     ```hcl
-    locals {
-      group_a = [
-        "charlie",
-        "alpha",
+    foods = concat(
+      [ #fruits
+        "apple",
+        "banana",
+        "cherry",
+      ],
+      [ #vegetables
+        "broccoli",
+        "carrot",
+        "tomato",
       ]
-      group_b = [
-        "bravo",
-      ]
-    }
-
-    resource "something" "example" {
-      # Use concat or other functions as needed
-      combined_list = concat(local.group_a, local.group_b)
-      # Or use the groups separately
-      list_a = local.group_a
-      list_b = local.group_b
-    }
+    )
     ```
 
     In this case, `tfsort` would sort the elements within `local.group_a` and `local.group_b` individually, but the `concat` function would preserve the group order in `combined_list`.

--- a/internal/sorter/testdata/input_5.tf
+++ b/internal/sorter/testdata/input_5.tf
@@ -1,0 +1,7 @@
+resource "a" "a" {
+  allowed_ports = toset([
+    "https-443-tcp",
+    "http-80-tcp",
+    "ssh-22-tcp",
+  ])
+}

--- a/internal/sorter/testdata/input_6.tf
+++ b/internal/sorter/testdata/input_6.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "config_storage" {}
+
+resource "aws_iam_role" "app_role" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "asset_storage" {}

--- a/internal/sorter/testdata/input_7.tf
+++ b/internal/sorter/testdata/input_7.tf
@@ -1,0 +1,49 @@
+resource "a" "concat_list1" {
+  foods = concat(
+    [ #fruits
+      "cherry",
+      "apple",
+      "banana",
+    ],
+    [ #vegetables
+      "tomato",
+      "carrot",
+      "broccoli",
+    ]
+  )
+}
+
+resource "a" "concat_list2" {
+  foods = concat(
+    #fruits
+    [
+      "cherry",
+      "apple",
+      "banana",
+    ],
+    #vegetables
+    [
+      "tomato",
+      "carrot",
+      "broccoli",
+    ]
+  )
+}
+
+resource "a" "concat_list3" {
+  foods = concat(
+    [
+      #fruits
+      "cherry",
+      "apple",
+      "banana",
+    ],
+    [
+      #vegetables
+      "tomato",
+      "carrot",
+      "broccoli",
+    ]
+  )
+}
+

--- a/internal/sorter/testdata/want_5.tf
+++ b/internal/sorter/testdata/want_5.tf
@@ -1,0 +1,7 @@
+resource "a" "a" {
+  allowed_ports = toset([
+    "http-80-tcp",
+    "https-443-tcp",
+    "ssh-22-tcp",
+  ])
+}

--- a/internal/sorter/testdata/want_6.tf
+++ b/internal/sorter/testdata/want_6.tf
@@ -1,0 +1,7 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "app_role" {}
+
+resource "aws_s3_bucket" "asset_storage" {}
+
+resource "aws_s3_bucket" "config_storage" {}

--- a/internal/sorter/testdata/want_7.tf
+++ b/internal/sorter/testdata/want_7.tf
@@ -1,0 +1,48 @@
+resource "a" "concat_list1" {
+  foods = concat(
+    [ #fruits
+      "apple",
+      "banana",
+      "cherry",
+    ],
+    [ #vegetables
+      "broccoli",
+      "carrot",
+      "tomato",
+    ]
+  )
+}
+
+resource "a" "concat_list2" {
+  foods = concat(
+    #fruits
+    [
+      "apple",
+      "banana",
+      "cherry",
+    ],
+    #vegetables
+    [
+      "broccoli",
+      "carrot",
+      "tomato",
+    ]
+  )
+}
+
+resource "a" "concat_list3" {
+  foods = concat(
+    [
+      "apple",
+      "banana",
+      #fruits
+      "cherry",
+    ],
+    [
+      "broccoli",
+      "carrot",
+      #vegetables
+      "tomato",
+    ]
+  )
+}


### PR DESCRIPTION
This pull request adds new test data files to the `internal/sorter` module, introducing resources and their expected sorted outputs. The changes primarily focus on defining and validating resource sorting behavior.

### Additions to test input files:

* [`internal/sorter/testdata/input_5.tf`](diffhunk://#diff-4c42545387f605b5757ecf1a424bbbee19aed9b18fa6d7828f2e6d3cae8a36e6R1-R7): Added a resource `a` with an `allowed_ports` attribute containing a set of port definitions.
* [`internal/sorter/testdata/input_6.tf`](diffhunk://#diff-c9dcc1c8b6000551ea7db6344c6e56d15d84745c8b97bffced9ad736edd79c7aR1-R7): Added multiple AWS resources, including `aws_s3_bucket`, `aws_iam_role`, and `aws_caller_identity`.

### Additions to expected output files:

* [`internal/sorter/testdata/want_5.tf`](diffhunk://#diff-f94f87ae249d82555447758d32ccc433a7a6ea3f1ea1db06242e42632b4d827cR1-R7): Defined the expected sorted order of the `allowed_ports` set for resource `a`.
* [`internal/sorter/testdata/want_6.tf`](diffhunk://#diff-22ef13efb672267196bbd4cfd1ef604169108408250c6bf85ca90a251c3e0f29R1-R7): Defined the expected sorted order of the AWS resources, ensuring logical grouping and ordering.